### PR TITLE
Update events to use same logic than page view

### DIFF
--- a/models/events/bigquery/snowplow_events.sql
+++ b/models/events/bigquery/snowplow_events.sql
@@ -33,7 +33,7 @@ relevant_events as (
     select *,
         row_number() over (partition by event_id order by dvce_created_tstamp) as dedupe
 
-    from events
+    from all_events
     where domain_sessionid is not null
 
 ),

--- a/models/events/schema.yml
+++ b/models/events/schema.yml
@@ -84,6 +84,9 @@ models:
             
         - name: session_id
           description: A visit / session identifier
+        
+        - name: session_index
+          description: A visit / session index
 
         - name: ip.address
           description: User IP address


### PR DESCRIPTION
## Description & motivation
The page views count from `snowplow_sessions` was not matching the one from `snowplow_events` given that they were using slightly different logic.
I've updated the `snowplow_events` model to match.
