### PR TITLE
Fix getting first duplicate event

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 #settings specifically for this models directory
 #config other dbt settings within ~/.dbt/profiles.yml
-name: 'snowplow'
-version: '0.20.1'
+name: "snowplow"
+version: "0.20.2"
 config-version: 2
 
 model-paths: ["models"]
@@ -19,11 +19,11 @@ vars:
   #'snowplow:context:web_page': TABLE OR {{ REF() }}
   #'snowplow:context:performance_timing': TABLE OR {{ REF() }} or FALSE
   #'snowplow:context:useragent': TABLE OR {{ REF() }} or FALSE
-  'snowplow:timezone': 'America/New_York'
-  'snowplow:page_ping_frequency': 30
-  'snowplow:app_ids': []
-  'snowplow:pass_through_columns': []
-  'snowplow:page_view_lookback_days': 1
+  "snowplow:timezone": "America/New_York"
+  "snowplow:page_ping_frequency": 30
+  "snowplow:app_ids": []
+  "snowplow:pass_through_columns": []
+  "snowplow:page_view_lookback_days": 1
 
 models:
   snowplow:

--- a/models/events/bigquery/snowplow_events_tmp.sql
+++ b/models/events/bigquery/snowplow_events_tmp.sql
@@ -17,21 +17,24 @@ with all_events as (
     from {{ ref('snowplow_base_events') }}
 
     {% if is_incremental() %}
-        
-        where date(collector_tstamp) >= 
+
+        where date(collector_tstamp) >=
             date_sub(
                 {{get_start_ts(this)}},
                 interval {{var('snowplow:page_view_lookback_days')}} day
             )
-    
+
     {% endif %}
-    
+
 ),
 
 relevant_events as (
 
     select *,
-        row_number() over (partition by event_id order by dvce_created_tstamp) as dedupe
+        row_number() over (
+            partition by event_id
+            order by dvce_created_tstamp, collector_tstamp
+        ) as dedupe
 
     from all_events
     where domain_sessionid is not null
@@ -118,7 +121,7 @@ select
         refr_urlquery as url_query,
         refr_urlfragment as url_fragment
     ) as referer,
-    
+
     -- standard event params
     se_category as event_category,
     se_action as event_action,
@@ -177,7 +180,7 @@ select
         geo_longitude as longitude,
         geo_timezone as timezone
     ) as geo,
-    
+
     -- user agent
     useragent as user_agent
 

--- a/models/events/bigquery/snowplow_events_tmp.sql
+++ b/models/events/bigquery/snowplow_events_tmp.sql
@@ -33,7 +33,7 @@ relevant_events as (
     select *,
         row_number() over (
             partition by event_id
-            order by dvce_created_tstamp, collector_tstamp
+            order by dvce_created_tstamp, dvce_sent_tstamp
         ) as dedupe
 
     from all_events


### PR DESCRIPTION
## Description & motivation
When filtering duplicate events, we were not ensuring that we were picking the first one. We have sorted also by device sent timestamp so that it selects the first one only.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
